### PR TITLE
Add CI deploy to ci.chatuino.net with rolling develop release

### DIFF
--- a/.github/workflows/ci_deploy.yml
+++ b/.github/workflows/ci_deploy.yml
@@ -1,0 +1,69 @@
+name: CI Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-deploy
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Delete existing develop release
+        run: gh release delete develop --yes --cleanup-tag || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create develop tag
+        run: |
+          git tag -f develop
+          git push origin develop --force
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --config .goreleaser.ci.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy to CI server
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.DEPLOY_SSH_SERVER }}
+          username: ${{ secrets.DEPLOY_SSH_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            cd ~/chatuino
+            git fetch origin ${{ github.sha }}
+            git checkout ${{ github.sha }}
+            cd docker
+            docker compose -f docker-compose.ci.yml pull
+            docker compose -f docker-compose.ci.yml up -d

--- a/.goreleaser.ci.yaml
+++ b/.goreleaser.ci.yaml
@@ -1,0 +1,57 @@
+version: 2
+
+before:
+  hooks:
+    - go mod verify
+    - go generate ./...
+
+dockers_v2:
+  - images:
+      - "ghcr.io/julez-dev/chatuino"
+    tags:
+      - "develop"
+    dockerfile: docker/Dockerfile
+    labels:
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.title": "{{.ProjectName}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "{{.Version}}"
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    tags:
+      - nodynamic
+      - netgo
+    ldflags:
+      - -s -w -X main.Version={{ .Version }} -X main.Commit={{.Commit}} -X main.Date={{ .CommitDate }}
+
+archives:
+  - formats: ["tar.gz"]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: ["zip"]
+
+changelog:
+  disable: true
+
+release:
+  prerelease: true
+  make_latest: false
+  name_template: "develop"

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -17,3 +17,17 @@ chatuino.net {
 www.chatuino.net {
 	redir https://chatuino.net{uri}
 }
+
+ci.chatuino.net {
+	header X-Robots-Tag "noindex, nofollow"
+
+	@blocked {
+		path /internal /internal/*
+	}
+
+	respond @blocked 403 {
+		body "Access denied"
+	}
+
+	reverse_proxy chatuino-ci:3000
+}

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -1,0 +1,60 @@
+services:
+  redis-ci:
+    image: redis:8-alpine
+    container_name: chatuino-redis-ci
+    restart: unless-stopped
+    command: >
+      sh -c "redis-server --requirepass $$(cat /run/secrets/redis_password)"
+    secrets:
+      - redis_password
+    volumes:
+      - redis-ci-data:/data
+    healthcheck:
+      test: redis-cli --no-auth-warning -a $$(cat /run/secrets/redis_password) ping | grep PONG
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - proxy
+
+  chatuino-ci:
+    image: ghcr.io/julez-dev/chatuino:develop
+    container_name: chatuino-ci
+    restart: unless-stopped
+    entrypoint:
+      [
+        "/bin/sh",
+        "-c",
+        "export CHATUINO_CLIENT_SECRET=$$(cat /run/secrets/twitch_client_secret) CHATUINO_REDIS_PASSWORD=$$(cat /run/secrets/redis_password) ; chatuino --log server --redirect-url=https://ci.chatuino.net/auth/redirect",
+      ]
+    secrets:
+      - twitch_client_secret
+      - redis_password
+    environment:
+      - "CHATUINO_CLIENT_ID=jliqj1q6nmp0uh5ofangdx4iac7yd9"
+      - "CHATUINO_ADDR=:3000"
+      - "CHATUINO_REDIS_ADDR=redis-ci:6379"
+      - "CHATUINO_PROXY_RATELIMIT=true"
+    healthcheck:
+      test: curl --fail http://localhost:3000/internal/health || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    depends_on:
+      redis-ci:
+        condition: service_healthy
+    networks:
+      - proxy
+
+secrets:
+  twitch_client_secret:
+    file: ./secrets/twitch_client_secret.txt
+  redis_password:
+    file: ./secrets/redis_password.txt
+
+volumes:
+  redis-ci-data:
+
+networks:
+  proxy:
+    external: true


### PR DESCRIPTION
## Summary
- Adds automatic deployment to ci.chatuino.net on every push to main
- Creates rolling "develop" pre-release (replaces previous on each build)
- No AUR publishing for CI builds

## Manual steps after merge
1. Add DNS A/AAAA record for `ci.chatuino.net` in Hetzner pointing to server IP
2. First deploy: `cd ~/chatuino/docker && docker compose -f docker-compose.ci.yml up -d`