### PR TITLE
feat: add configuration option to disable badges entirely

### DIFF
--- a/doc/SETTINGS.md
+++ b/doc/SETTINGS.md
@@ -26,6 +26,7 @@ chat:
   # NOTE: Read the README for more information about emote rendering before enabling this feature
   graphic_emotes: true # Display emotes as images instead of text; Default: false
   graphic_badges: true # Display badges as images instead of text; Default: false
+  disable_badges: false # Hide badges entirely; Default: false
 custom_commands:
   # Custom commands are available as command suggestions
   - trigger: "/ocean"

--- a/save/settings.go
+++ b/save/settings.go
@@ -33,6 +33,7 @@ type ModerationSettings struct {
 type ChatSettings struct {
 	GraphicBadges              bool `yaml:"graphic_badges"`
 	GraphicEmotes              bool `yaml:"graphic_emotes"`
+	DisableBadges              bool `yaml:"disable_badges"`
 	DisablePaddingWrappedLines bool `yaml:"disable_padding_wrapped_lines"`
 }
 

--- a/ui/mainui/chat.go
+++ b/ui/mainui/chat.go
@@ -673,7 +673,7 @@ func (c *chatWindow) messageToText(event chatEventMessage) []string {
 			parts = append(parts, "|"+event.channelGuestDisplayName+"|")
 		}
 
-		if len(event.displayModifier.badgeReplacement) > 0 {
+		if len(event.displayModifier.badgeReplacement) > 0 && !c.deps.UserConfig.Settings.Chat.DisableBadges {
 			badges := formatBadgeReplacement(c.deps.UserConfig.Settings, event.displayModifier.badgeReplacement)
 			if c.deps.UserConfig.Settings.Chat.GraphicBadges {
 				// Hair space (U+200A) - narrower gap since badges have pixel padding


### PR DESCRIPTION
Add configuration option to disable badges entirely. This is useful when viewing on narrow screens.

<img width="437" height="851" alt="image" src="https://github.com/user-attachments/assets/c4de2486-09aa-499f-92ee-8773879c11e5" />

#### notes

I can't edit the PR title :(