### PR TITLE
feature: unify all loading states with spinner.Points animation

### DIFF
--- a/ui/accountui/create.go
+++ b/ui/accountui/create.go
@@ -53,7 +53,7 @@ func newCreateModel(width, height int, clientID, apiHost string, keymap save.Key
 
 	s := spinner.New()
 
-	s.Spinner = spinner.Dot
+	s.Spinner = spinner.Points
 	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color(theme.ListFontColor))
 
 	return createModel{

--- a/ui/mainui/broadcast_tab.go
+++ b/ui/mainui/broadcast_tab.go
@@ -172,7 +172,7 @@ func newBroadcastTab(
 		lastMessages: cache,
 		deps:         deps,
 		modFetcher:   ivr.NewAPI(http.DefaultClient),
-		spinner:      spinner.New(spinner.WithSpinner(customEllipsisSpinner)),
+		spinner:      spinner.New(spinner.WithSpinner(loadingSpinner)),
 	}
 }
 
@@ -748,7 +748,7 @@ func (t *broadcastTab) View() string {
 			MaxHeight(t.height).
 			AlignHorizontal(lipgloss.Center).
 			AlignVertical(lipgloss.Center).
-			Render(t.spinner.View() + " Loading")
+			Render(t.spinner.View() + " Loading channel")
 	}
 
 	builder := strings.Builder{}
@@ -832,7 +832,7 @@ func (t *broadcastTab) ViewWithoutStatusBar() string {
 			MaxHeight(t.height).
 			AlignHorizontal(lipgloss.Center).
 			AlignVertical(lipgloss.Center).
-			Render(t.spinner.View() + " Loading")
+			Render(t.spinner.View() + " Loading channel")
 	}
 
 	builder := strings.Builder{}

--- a/ui/mainui/emote_overview.go
+++ b/ui/mainui/emote_overview.go
@@ -45,10 +45,8 @@ type emoteOverview struct {
 	isLoaded      bool
 }
 
-var customEllipsisSpinner = spinner.Spinner{
-	Frames: []string{"   ", "  .", " ..", "..."},
-	FPS:    time.Second / 3, //nolint:mnd
-}
+// loadingSpinner is the unified spinner used across all loading states.
+var loadingSpinner = spinner.Points
 
 func NewEmoteOverview(channelID string, cache EmoteCache, replacer EmoteReplacer, width, height int) *emoteOverview {
 	vp := viewport.New(width, height)
@@ -61,7 +59,7 @@ func NewEmoteOverview(channelID string, cache EmoteCache, replacer EmoteReplacer
 		channelID:     channelID,
 		emoteReplacer: replacer,
 		vp:            vp,
-		spinner:       spinner.New(spinner.WithSpinner(customEllipsisSpinner)),
+		spinner:       spinner.New(spinner.WithSpinner(loadingSpinner)),
 		ctx:           ctx,
 		cancel:        cancel,
 	}
@@ -167,7 +165,7 @@ func (e *emoteOverview) Update(msg tea.Msg) (*emoteOverview, tea.Cmd) {
 
 func (e *emoteOverview) View() string {
 	if !e.isLoaded {
-		return lipgloss.NewStyle().Width(e.vp.Width).Height(e.vp.Height).AlignHorizontal(lipgloss.Center).AlignVertical(lipgloss.Center).Render(e.spinner.View() + " Loading Emote Overview")
+		return lipgloss.NewStyle().Width(e.vp.Width).Height(e.vp.Height).AlignHorizontal(lipgloss.Center).AlignVertical(lipgloss.Center).Render(e.spinner.View() + " Loading emote overview")
 	}
 
 	return e.vp.View()

--- a/ui/mainui/root.go
+++ b/ui/mainui/root.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/julez-dev/chatuino/emote"
@@ -151,6 +152,7 @@ func NewUI(
 		splash: splash{
 			keymap:            dependencies.Keymap,
 			userConfiguration: dependencies.UserConfig,
+			spinner:           spinner.New(spinner.WithSpinner(loadingSpinner)),
 		},
 		header:         header,
 		help:           newHelp(10, 10, dependencies),
@@ -164,6 +166,7 @@ func NewUI(
 func (r *Root) Init() tea.Cmd {
 	return tea.Batch(
 		tea.SetWindowTitle("Chatuino"),
+		r.splash.Init(),
 		func() tea.Msg {
 			state, err := r.dependencies.AppStateManager.LoadAppState()
 			if err != nil {
@@ -663,6 +666,11 @@ func (r *Root) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
+	}
+
+	if !r.hasLoadedSession {
+		r.splash, cmd = r.splash.Update(msg)
+		cmds = append(cmds, cmd)
 	}
 
 	r.header, cmd = r.header.Update(msg)

--- a/ui/mainui/splash.go
+++ b/ui/mainui/splash.go
@@ -5,6 +5,7 @@ import (
 
 	_ "embed"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/julez-dev/chatuino/save"
@@ -17,14 +18,17 @@ type splash struct {
 	width, height     int
 	keymap            save.KeyMap
 	userConfiguration UserConfiguration
+	spinner           spinner.Model
 }
 
 func (s splash) Init() tea.Cmd {
-	return nil
+	return s.spinner.Tick
 }
 
-func (s splash) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	return s, nil
+func (s splash) Update(msg tea.Msg) (splash, tea.Cmd) {
+	var cmd tea.Cmd
+	s.spinner, cmd = s.spinner.Update(msg)
+	return s, cmd
 }
 
 func (s splash) view(loading bool, err error) string {
@@ -39,7 +43,7 @@ func (s splash) view(loading bool, err error) string {
 
 	var help string
 	if loading {
-		help = "loading initial state..."
+		help = s.spinner.View() + " Loading initial state"
 	} else if err != nil {
 		help = err.Error() + "\n"
 		help += "Use " + lipgloss.NewStyle().Foreground(lipgloss.Color(lipgloss.Color(s.userConfiguration.Theme.SplashHighlightColor))).Render(keyDisplay) + " to create a new tab and join a channel"

--- a/ui/mainui/status.go
+++ b/ui/mainui/status.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/julez-dev/chatuino/twitch/twitchapi"
@@ -77,6 +78,7 @@ type streamStatus struct {
 	deps          *DependencyContainer
 
 	userConfig UserConfiguration
+	spinner    spinner.Model
 
 	settings      twitchapi.ChatSettingData
 	err           error
@@ -91,11 +93,12 @@ func newStreamStatus(width, height int, tab *broadcastTab, accountID, channelID 
 		width:     width,
 		height:    height,
 		channelID: channelID,
+		spinner:   spinner.New(spinner.WithSpinner(loadingSpinner)),
 	}
 }
 
 func (s *streamStatus) Init() tea.Cmd {
-	return func() tea.Msg {
+	return tea.Batch(s.spinner.Tick, func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 		defer cancel()
 
@@ -119,7 +122,7 @@ func (s *streamStatus) Init() tea.Cmd {
 			settings: settingsResp.Data[0],
 			err:      err,
 		}
-	}
+	})
 }
 
 func (s *streamStatus) Update(msg tea.Msg) (*streamStatus, tea.Cmd) {
@@ -137,6 +140,12 @@ func (s *streamStatus) Update(msg tea.Msg) (*streamStatus, tea.Cmd) {
 		return s, nil
 	}
 
+	if !s.isDataFetched {
+		var cmd tea.Cmd
+		s.spinner, cmd = s.spinner.Update(msg)
+		return s, cmd
+	}
+
 	return s, nil
 }
 
@@ -144,7 +153,7 @@ func (s *streamStatus) View() string {
 	padded := lipgloss.NewStyle().MaxWidth(s.width).Render
 
 	if !s.isDataFetched {
-		return padded("Fetching chat settings...")
+		return padded(s.spinner.View() + " Fetching chat settings")
 	}
 
 	if s.err != nil {

--- a/ui/mainui/user_inspect.go
+++ b/ui/mainui/user_inspect.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/julez-dev/chatuino/twitch/ivr"
@@ -39,8 +40,9 @@ type userInspect struct {
 	badges          []twitchirc.Badge
 	formattedBadges wordReplacement
 
-	ivr  *ivr.API
-	deps *DependencyContainer
+	ivr     *ivr.API
+	deps    *DependencyContainer
+	spinner spinner.Model
 
 	chatWindow *chatWindow
 }
@@ -59,6 +61,7 @@ func newUserInspect(tabID string, width, height int, user, channel string, accou
 		user:      user,
 		ivr:       ivr.NewAPI(http.DefaultClient),
 		deps:      deps,
+		spinner:   spinner.New(spinner.WithSpinner(loadingSpinner)),
 		// start chat window in full size, will be resized once data is fetched
 		chatWindow: c,
 	}
@@ -71,7 +74,7 @@ func (u *userInspect) Init() tea.Cmd {
 func (u *userInspect) init(initialEvents []chatEventMessage) tea.Cmd {
 	var cmds []tea.Cmd
 
-	cmds = append(cmds, u.chatWindow.Init())
+	cmds = append(cmds, u.chatWindow.Init(), u.spinner.Tick)
 	cmds = append(cmds, func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 		defer cancel()
@@ -209,6 +212,12 @@ func (u *userInspect) Update(msg tea.Msg) (*userInspect, tea.Cmd) {
 		return u, tea.Batch(cmds...)
 	}
 
+	// update spinner while loading
+	if !u.isDataFetched {
+		u.spinner, cmd = u.spinner.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+
 	chatEvent, ok := msg.(chatEventMessage)
 
 	// we don't need to intervene if the message is not a chat event, the window can handle it
@@ -297,8 +306,7 @@ func (u *userInspect) renderUserInfo() string {
 	styleCentered := style.MaxWidth(u.width).AlignHorizontal(lipgloss.Center)
 
 	if !u.isDataFetched {
-		// render with some new lines to look a little bit better once all data is available
-		return styleCentered.Render("\n", "Fetching data...", "\n")
+		return styleCentered.Render("\n", u.spinner.View()+" Fetching user data", "\n")
 	}
 
 	if u.err != nil {


### PR DESCRIPTION
## Summary

- Replace all different loading indicators (custom ellipsis, `spinner.Dot`, static text) with a single `spinner.Points` animation across every loading state
- Add animated spinners to previously static loading screens: splash, user inspect, and status bar
- Define `loadingSpinner` as single source of truth in `mainui` package; `accountui` references `spinner.Points` directly

### Loading states unified (7 locations):

| Location | Before | After |
|----------|--------|-------|
| Splash screen | Static `"loading initial state..."` | Animated `"⊙ Loading initial state"` |
| Broadcast tab | Custom ellipsis `"... Loading"` | `"⊙ Loading channel"` |
| Emote overview | Custom ellipsis `"... Loading Emote Overview"` | `"⊙ Loading emote overview"` |
| Account create | `spinner.Dot` (braille) | `spinner.Points` |
| User inspect | Static `"Fetching data..."` | Animated `"⊙ Fetching user data"` |
| Status bar | Static `"Fetching chat settings..."` | Animated `"⊙ Fetching chat settings"` |
| Stream info | Empty string (unchanged) | N/A — no loading state needed |