### PR TITLE
feature: check for new version on startup and notify user

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/spf13/afero v1.15.0
 	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/image v0.36.0
+	golang.org/x/mod v0.33.0
 	modernc.org/sqlite v1.45.0
 	resenje.org/singleflight v0.4.3
 )

--- a/main.go
+++ b/main.go
@@ -254,6 +254,7 @@ func main() {
 					Settings: settings,
 					Theme:    theme,
 				},
+				Version:              Version,
 				AppStateManager:      appStateManager,
 				Keymap:               keymap,
 				ServerAPI:            serverAPI,

--- a/server.go
+++ b/server.go
@@ -76,6 +76,7 @@ var serverCMD = &cli.Command{
 				ClientSecret:         command.String("client-secret"),
 				RedirectURL:          command.String("redirect-url"),
 				EnableProxyRateLimit: command.Bool("enable-ratelimit"),
+				Version:              Version,
 				Redis: server.RedisConfig{
 					Addr:     command.String("redis-addr"),
 					Password: command.String("redis-password"),

--- a/server/api.go
+++ b/server/api.go
@@ -25,6 +25,7 @@ type Config struct {
 	RedirectURL          string
 	Redis                RedisConfig
 	EnableProxyRateLimit bool
+	Version              string
 }
 
 type API struct {

--- a/server/client.go
+++ b/server/client.go
@@ -145,6 +145,16 @@ func (c *Client) CheckLink(ctx context.Context, targetURL string) (CheckLinkResp
 	return data, nil
 }
 
+// Version methods
+
+func (c *Client) GetLatestVersion(ctx context.Context) (string, error) {
+	resp, err := do[VersionResponse](ctx, c, c.baseURL+"/version")
+	if err != nil {
+		return "", err
+	}
+	return resp.Version, nil
+}
+
 // Twitch API proxy methods (/ttv/*)
 
 func (c *Client) GetGlobalEmotes(ctx context.Context) (twitchapi.EmoteResponse, error) {

--- a/server/handler.go
+++ b/server/handler.go
@@ -261,6 +261,18 @@ func (a *API) handleGetHealth() http.HandlerFunc {
 
 const installScriptURL = "https://raw.githubusercontent.com/julez-dev/chatuino/main/install/install.sh"
 
+// VersionResponse is the JSON response for the /version endpoint.
+type VersionResponse struct {
+	Version string `json:"version"`
+}
+
+func (a *API) handleGetVersion() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(VersionResponse{Version: a.conf.Version})
+	})
+}
+
 func (a *API) handleInstallScript() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, installScriptURL, http.StatusFound)

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleGetVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns configured version", func(t *testing.T) {
+		t.Parallel()
+
+		api := createTestAPI(t)
+		api.conf.Version = "0.7.0"
+		handler := api.handleGetVersion()
+
+		req := httptest.NewRequest(http.MethodGet, "/version", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+		var resp VersionResponse
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		require.Equal(t, "0.7.0", resp.Version)
+	})
+
+	t.Run("returns dev when version unset", func(t *testing.T) {
+		t.Parallel()
+
+		api := createTestAPI(t)
+		handler := api.handleGetVersion()
+
+		req := httptest.NewRequest(http.MethodGet, "/version", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var resp VersionResponse
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		require.Empty(t, resp.Version)
+	})
+}

--- a/server/router.go
+++ b/server/router.go
@@ -17,6 +17,7 @@ func router(logger zerolog.Logger, api *API) *chi.Mux {
 	)
 
 	c.Get("/install", api.handleInstallScript())
+	c.Get("/version", api.handleGetVersion())
 
 	c.Route("/internal", func(r chi.Router) {
 		r.Get("/health", api.handleGetHealth())

--- a/ui/mainui/broadcast_tab.go
+++ b/ui/mainui/broadcast_tab.go
@@ -119,8 +119,9 @@ type broadcastTab struct {
 	isUniqueOnlyChat bool
 	lastMessages     *ttlcache.Cache[string, struct{}]
 
-	isUserMod bool
-	focused   bool
+	isUserMod  bool
+	focused    bool
+	updateInfo *UpdateInfo
 
 	channelDataLoaded         bool
 	pendingChannelSuggestions []string

--- a/ui/mainui/dependencies.go
+++ b/ui/mainui/dependencies.go
@@ -55,6 +55,7 @@ type ChatuinoServer interface {
 	APIClient
 	RefreshToken(ctx context.Context, refreshToken string) (string, string, error)
 	CheckLink(ctx context.Context, targetURL string) (server.CheckLinkResponse, error)
+	GetLatestVersion(ctx context.Context) (string, error)
 }
 
 type UserEmoteClient interface {
@@ -94,6 +95,7 @@ type DependencyContainer struct {
 	UserConfig UserConfiguration
 	Keymap     save.KeyMap
 	Accounts   []save.Account
+	Version    string
 
 	ServerAPI      ChatuinoServer
 	APIUserClients map[string]APIClient

--- a/ui/mainui/message.go
+++ b/ui/mainui/message.go
@@ -67,6 +67,12 @@ type EventSubMessage struct {
 	Payload eventsub.Message[eventsub.NotificationPayload]
 }
 
+// versionCheckMessage carries the result of the startup version check.
+type versionCheckMessage struct {
+	info UpdateInfo
+	err  error
+}
+
 // polledStreamInfoMessage comes when current stream info is refreshed
 type polledStreamInfoMessage struct {
 	streamInfos []setStreamInfoMessage

--- a/ui/mainui/root.go
+++ b/ui/mainui/root.go
@@ -129,6 +129,7 @@ type Root struct {
 	tabCursor          int
 	tabs               []tab
 	channelSuggestions []string // cached for broadcast to new tabs
+	updateInfo         *UpdateInfo
 }
 
 func NewUI(
@@ -341,6 +342,7 @@ func (r *Root) Init() tea.Cmd {
 		},
 		r.tickPollStreamInfos(),
 		r.imageCleanUpCommand(),
+		r.checkVersionCommand(),
 	)
 }
 
@@ -356,6 +358,8 @@ func (r *Root) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case imageCleanupTickMessage:
 		io.WriteString(os.Stdout, msg.deletionCommand)
 		return r, r.imageCleanUpCommand()
+	case versionCheckMessage:
+		return r, r.handleVersionCheck(msg)
 	case joinChannelMessage:
 		r.screenType = mainScreen
 
@@ -953,6 +957,7 @@ func (r *Root) createTab(account save.Account, channel string, kind tabKind) (ta
 		headerHeight := r.getHeaderHeight()
 
 		nTab := newBroadcastTab(id, r.width, r.height-headerHeight, account, channel, r.dependencies)
+		nTab.updateInfo = r.updateInfo
 		return nTab, cmd
 	case mentionTabKind:
 		id, cmd := r.header.AddTab("mentioned", "all")
@@ -1056,6 +1061,38 @@ func (r *Root) prevTab() {
 		r.header.SelectTab(r.tabs[r.tabCursor].ID())
 		r.tabs[r.tabCursor].Focus()
 	}
+}
+
+func (r *Root) checkVersionCommand() tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+
+		info, err := checkForUpdate(ctx, r.dependencies.ServerAPI, r.dependencies.Version)
+		return versionCheckMessage{info: info, err: err}
+	}
+}
+
+func (r *Root) handleVersionCheck(msg versionCheckMessage) tea.Cmd {
+	if msg.err != nil {
+		log.Logger.Err(msg.err).Msg("version check failed")
+		return nil
+	}
+
+	if !msg.info.HasUpdate {
+		return nil
+	}
+
+	r.updateInfo = &msg.info
+	r.splash.updateInfo = &msg.info
+
+	for _, t := range r.tabs {
+		if bt, ok := t.(*broadcastTab); ok {
+			bt.updateInfo = r.updateInfo
+		}
+	}
+
+	return nil
 }
 
 func (r *Root) handlePersistedDataLoaded(msg persistedDataLoadedMessage) tea.Cmd {

--- a/ui/mainui/splash.go
+++ b/ui/mainui/splash.go
@@ -19,6 +19,7 @@ type splash struct {
 	keymap            save.KeyMap
 	userConfiguration UserConfiguration
 	spinner           spinner.Model
+	updateInfo        *UpdateInfo
 }
 
 func (s splash) Init() tea.Cmd {
@@ -51,8 +52,14 @@ func (s splash) view(loading bool, err error) string {
 		help = "Use " + lipgloss.NewStyle().Foreground(lipgloss.Color(lipgloss.Color(s.userConfiguration.Theme.SplashHighlightColor))).Render(keyDisplay) + " to create a new tab and join a channel"
 	}
 
+	var updateLine string
+	if s.updateInfo != nil && s.updateInfo.HasUpdate {
+		highlightStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(s.userConfiguration.Theme.SplashHighlightColor))
+		updateLine = "\n" + highlightStyle.Render("New update available: "+s.updateInfo.LatestVersion) + " (current: " + s.updateInfo.CurrentVersion + ")"
+	}
+
 	logo := splashArt
-	splash := style.Render(logo + "\n" + "Welcome to " + name.String() + "!\n" + help)
+	splash := style.Render(logo + "\n" + "Welcome to " + name.String() + "!\n" + help + updateLine)
 
 	return splash
 }

--- a/ui/mainui/status.go
+++ b/ui/mainui/status.go
@@ -225,5 +225,13 @@ func (s *streamStatus) View() string {
 		settingsBuilder.WriteString("Unique Only")
 	}
 
+	if s.tab.updateInfo != nil && s.tab.updateInfo.HasUpdate {
+		highlightStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(s.deps.UserConfig.Theme.SplashHighlightColor))
+		if settingsBuilder.Len() > 0 {
+			settingsBuilder.WriteString(" | ")
+		}
+		settingsBuilder.WriteString(highlightStyle.Render("New update available: " + s.tab.updateInfo.LatestVersion))
+	}
+
 	return padded(stateStr + lipgloss.NewStyle().AlignHorizontal(lipgloss.Right).Width(s.width-lipgloss.Width(stateStr)).Render(settingsBuilder.String()))
 }

--- a/ui/mainui/version_check.go
+++ b/ui/mainui/version_check.go
@@ -1,0 +1,57 @@
+package mainui
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/mod/semver"
+)
+
+// UpdateInfo holds the result of a version check.
+type UpdateInfo struct {
+	CurrentVersion string
+	LatestVersion  string
+	HasUpdate      bool
+}
+
+// latestVersionFetcher is the subset of ChatuinoServer needed for version checks.
+type latestVersionFetcher interface {
+	GetLatestVersion(ctx context.Context) (string, error)
+}
+
+// checkForUpdate queries the server for the latest version and compares it
+// against the current build version. Returns a zero UpdateInfo when the
+// current version is a dev build or the fetcher is nil.
+func checkForUpdate(ctx context.Context, checker latestVersionFetcher, currentVersion string) (UpdateInfo, error) {
+	if checker == nil || currentVersion == "dev" {
+		return UpdateInfo{}, nil
+	}
+
+	current := ensureVPrefix(currentVersion)
+	if !semver.IsValid(current) {
+		return UpdateInfo{}, fmt.Errorf("current version %q is not valid semver", currentVersion)
+	}
+
+	latest, err := checker.GetLatestVersion(ctx)
+	if err != nil {
+		return UpdateInfo{}, fmt.Errorf("fetch latest version: %w", err)
+	}
+
+	latestCanonical := ensureVPrefix(latest)
+	if !semver.IsValid(latestCanonical) {
+		return UpdateInfo{}, fmt.Errorf("server version %q is not valid semver", latest)
+	}
+
+	return UpdateInfo{
+		CurrentVersion: current,
+		LatestVersion:  latestCanonical,
+		HasUpdate:      semver.Compare(latestCanonical, current) > 0,
+	}, nil
+}
+
+func ensureVPrefix(v string) string {
+	if len(v) > 0 && v[0] != 'v' {
+		return "v" + v
+	}
+	return v
+}

--- a/ui/mainui/version_check_test.go
+++ b/ui/mainui/version_check_test.go
@@ -1,0 +1,98 @@
+package mainui
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stubVersionChecker struct {
+	version string
+	err     error
+}
+
+func (s stubVersionChecker) GetLatestVersion(_ context.Context) (string, error) {
+	return s.version, s.err
+}
+
+func TestCheckForUpdate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("skip dev build", func(t *testing.T) {
+		t.Parallel()
+		info, err := checkForUpdate(context.Background(), stubVersionChecker{version: "1.0.0"}, "dev")
+		require.NoError(t, err)
+		require.False(t, info.HasUpdate)
+	})
+
+	t.Run("skip nil checker", func(t *testing.T) {
+		t.Parallel()
+		info, err := checkForUpdate(context.Background(), nil, "0.6.0")
+		require.NoError(t, err)
+		require.False(t, info.HasUpdate)
+	})
+
+	t.Run("update available", func(t *testing.T) {
+		t.Parallel()
+		info, err := checkForUpdate(context.Background(), stubVersionChecker{version: "v0.7.0"}, "v0.6.0")
+		require.NoError(t, err)
+		require.True(t, info.HasUpdate)
+		require.Equal(t, "v0.7.0", info.LatestVersion)
+		require.Equal(t, "v0.6.0", info.CurrentVersion)
+	})
+
+	t.Run("update available without v prefix", func(t *testing.T) {
+		t.Parallel()
+		info, err := checkForUpdate(context.Background(), stubVersionChecker{version: "0.7.0"}, "0.6.0")
+		require.NoError(t, err)
+		require.True(t, info.HasUpdate)
+		require.Equal(t, "v0.7.0", info.LatestVersion)
+		require.Equal(t, "v0.6.0", info.CurrentVersion)
+	})
+
+	t.Run("no update same version", func(t *testing.T) {
+		t.Parallel()
+		info, err := checkForUpdate(context.Background(), stubVersionChecker{version: "v0.6.0"}, "v0.6.0")
+		require.NoError(t, err)
+		require.False(t, info.HasUpdate)
+	})
+
+	t.Run("no update current newer", func(t *testing.T) {
+		t.Parallel()
+		info, err := checkForUpdate(context.Background(), stubVersionChecker{version: "v0.5.0"}, "v0.6.0")
+		require.NoError(t, err)
+		require.False(t, info.HasUpdate)
+		require.Equal(t, "v0.5.0", info.LatestVersion)
+		require.Equal(t, "v0.6.0", info.CurrentVersion)
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		t.Parallel()
+		_, err := checkForUpdate(context.Background(), stubVersionChecker{err: errors.New("connection refused")}, "v0.6.0")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "connection refused")
+	})
+
+	t.Run("invalid current version", func(t *testing.T) {
+		t.Parallel()
+		_, err := checkForUpdate(context.Background(), stubVersionChecker{version: "v0.7.0"}, "not-semver")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not valid semver")
+	})
+
+	t.Run("invalid server version", func(t *testing.T) {
+		t.Parallel()
+		_, err := checkForUpdate(context.Background(), stubVersionChecker{version: "garbage"}, "v0.6.0")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not valid semver")
+	})
+
+	t.Run("prerelease ordering", func(t *testing.T) {
+		t.Parallel()
+		info, err := checkForUpdate(context.Background(), stubVersionChecker{version: "v1.0.0"}, "v1.0.0-rc.1")
+		require.NoError(t, err)
+		require.True(t, info.HasUpdate)
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `/version` endpoint to chatuino server returning the build version as JSON
- On TUI startup, checks server for latest version (3s timeout, skipped for dev builds)
- Displays "New update available: vX.Y.Z" in the status bar of broadcast tabs and on the splash screen
- Uses `golang.org/x/mod/semver` for version comparison
- Graceful: errors are logged silently, self-hosted servers with older versions produce no false notification