### PR TITLE
feature: enhanced search with composable filters, regex, negation

### DIFF
--- a/doc/FEATURES.md
+++ b/doc/FEATURES.md
@@ -18,7 +18,29 @@ Chatuino displays various Twitch events including messages, sub-gifts, timeouts,
 
 Use local commands like `/localsubscribers` and `/uniqueonly` to filter chat locally.
 
-Press `/` to start a fuzzy search for messages or usernames. Navigate with arrow keys.
+Press `/` to search chat messages. Navigate results with arrow keys, press Enter to jump to a match, or Escape to cancel.
+
+### Search Syntax
+
+By default, typing a term searches both message content and usernames. Use prefixes to target specific fields or apply advanced filters:
+
+| Filter | Description |
+|---|---|
+| `hello` | message or username contains "hello" |
+| `content:term` | message content contains term |
+| `user:term` | username contains term |
+| `badge:name` | user has badge (e.g. `badge:moderator`) |
+| `is:mod` | mod messages only (also: `sub`, `vip`, `first`) |
+| `/pattern/` | regex on content and username |
+| `regex:pattern` | regex on content and username |
+| `user:/pattern/` | regex scoped to username only |
+| `content:/pattern/` | regex scoped to content only |
+| `-filter` | negate any filter (e.g. `-user:nightbot`) |
+| `"quoted value"` | match a phrase with spaces |
+
+Multiple filters are combined with AND. For example, `user:julez content:GG is:sub` matches messages from "julez" containing "GG" that are from a subscriber.
+
+Aliases: `msg:` for `content:`, `from:` for `user:`.
 
 Enable insert mode (for writing messages/commands) with `i` and exit with Escape. Press Enter to send a message, or Alt+Enter to send while keeping the text in the input.
 A simple duplication bypass is included when your message matches the last message.

--- a/search/matcher.go
+++ b/search/matcher.go
@@ -1,0 +1,186 @@
+// Package search provides composable chat message matchers
+// that can be combined to build structured search queries.
+package search
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/julez-dev/chatuino/twitch/twitchirc"
+)
+
+// Matcher tests whether a PrivateMessage satisfies a search criterion.
+type Matcher interface {
+	Match(msg *twitchirc.PrivateMessage) bool
+}
+
+// Property identifies a boolean field on PrivateMessage for property matching.
+type Property int
+
+const (
+	PropertyMod   Property = iota // Mod field
+	PropertySub                   // Subscriber field
+	PropertyVIP                   // VIP field
+	PropertyFirst                 // FirstMsg field
+)
+
+// ContentMatcher matches case-insensitive substrings in message content.
+type ContentMatcher struct {
+	search string // pre-lowered at construction
+}
+
+func NewContentMatcher(term string) *ContentMatcher {
+	return &ContentMatcher{search: strings.ToLower(term)}
+}
+
+func (m *ContentMatcher) Match(msg *twitchirc.PrivateMessage) bool {
+	return strings.Contains(strings.ToLower(msg.Message), m.search)
+}
+
+// UserMatcher matches case-insensitive substrings in the display name.
+type UserMatcher struct {
+	search string // pre-lowered at construction
+}
+
+func NewUserMatcher(term string) *UserMatcher {
+	return &UserMatcher{search: strings.ToLower(term)}
+}
+
+func (m *UserMatcher) Match(msg *twitchirc.PrivateMessage) bool {
+	return strings.Contains(strings.ToLower(msg.DisplayName), m.search)
+}
+
+// DefaultMatcher matches when either content or username contains the term.
+// Preserves backward-compatible behavior with the old search.
+type DefaultMatcher struct {
+	content *ContentMatcher
+	user    *UserMatcher
+}
+
+func NewDefaultMatcher(term string) *DefaultMatcher {
+	return &DefaultMatcher{
+		content: NewContentMatcher(term),
+		user:    NewUserMatcher(term),
+	}
+}
+
+func (m *DefaultMatcher) Match(msg *twitchirc.PrivateMessage) bool {
+	return m.content.Match(msg) || m.user.Match(msg)
+}
+
+// Field selects which message fields a matcher operates on.
+type Field int
+
+const (
+	FieldAny     Field = iota // match content OR username
+	FieldContent              // match message content only
+	FieldUser                 // match username only
+)
+
+// RegexMatcher matches a compiled regular expression against selected fields.
+type RegexMatcher struct {
+	re    *regexp.Regexp
+	field Field
+}
+
+// NewRegexMatcher compiles the pattern into a case-insensitive regex matching both content and username.
+// Returns an error if the pattern is invalid.
+func NewRegexMatcher(pattern string) (*RegexMatcher, error) {
+	return NewRegexMatcherField(pattern, FieldAny)
+}
+
+// NewRegexMatcherField compiles the pattern into a case-insensitive regex scoped to the given field.
+func NewRegexMatcherField(pattern string, field Field) (*RegexMatcher, error) {
+	re, err := regexp.Compile("(?i)" + pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RegexMatcher{re: re, field: field}, nil
+}
+
+func (m *RegexMatcher) Match(msg *twitchirc.PrivateMessage) bool {
+	switch m.field {
+	case FieldContent:
+		return m.re.MatchString(msg.Message)
+	case FieldUser:
+		return m.re.MatchString(msg.DisplayName)
+	default:
+		return m.re.MatchString(msg.Message) || m.re.MatchString(msg.DisplayName)
+	}
+}
+
+// BadgeMatcher matches when the user has a badge whose name contains the term.
+type BadgeMatcher struct {
+	search string // pre-lowered at construction
+}
+
+func NewBadgeMatcher(name string) *BadgeMatcher {
+	return &BadgeMatcher{search: strings.ToLower(name)}
+}
+
+func (m *BadgeMatcher) Match(msg *twitchirc.PrivateMessage) bool {
+	for _, b := range msg.Badges {
+		if strings.Contains(strings.ToLower(b.Name), m.search) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// PropertyMatcher matches a boolean property on the message.
+type PropertyMatcher struct {
+	prop Property
+}
+
+func NewPropertyMatcher(prop Property) *PropertyMatcher {
+	return &PropertyMatcher{prop: prop}
+}
+
+func (m *PropertyMatcher) Match(msg *twitchirc.PrivateMessage) bool {
+	switch m.prop {
+	case PropertyMod:
+		return msg.Mod
+	case PropertySub:
+		return msg.Subscriber
+	case PropertyVIP:
+		return msg.VIP
+	case PropertyFirst:
+		return msg.FirstMsg
+	default:
+		return false
+	}
+}
+
+// AndMatcher requires all child matchers to match. Short-circuits on first failure.
+type AndMatcher struct {
+	Matchers []Matcher
+}
+
+func NewAndMatcher(matchers ...Matcher) *AndMatcher {
+	return &AndMatcher{Matchers: matchers}
+}
+
+func (m *AndMatcher) Match(msg *twitchirc.PrivateMessage) bool {
+	for _, child := range m.Matchers {
+		if !child.Match(msg) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// NotMatcher inverts the result of the inner matcher.
+type NotMatcher struct {
+	Inner Matcher
+}
+
+func NewNotMatcher(inner Matcher) *NotMatcher {
+	return &NotMatcher{Inner: inner}
+}
+
+func (m *NotMatcher) Match(msg *twitchirc.PrivateMessage) bool {
+	return !m.Inner.Match(msg)
+}

--- a/search/matcher_test.go
+++ b/search/matcher_test.go
@@ -1,0 +1,289 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/julez-dev/chatuino/twitch/twitchirc"
+	"github.com/stretchr/testify/require"
+)
+
+func msg(displayName, message string) *twitchirc.PrivateMessage {
+	return &twitchirc.PrivateMessage{
+		DisplayName: displayName,
+		Message:     message,
+	}
+}
+
+func TestContentMatcher(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		term string
+		msg  *twitchirc.PrivateMessage
+		want bool
+	}{
+		{name: "exact match", term: "hello", msg: msg("user", "hello"), want: true},
+		{name: "substring", term: "ell", msg: msg("user", "hello"), want: true},
+		{name: "case insensitive", term: "HELLO", msg: msg("user", "hello world"), want: true},
+		{name: "no match", term: "xyz", msg: msg("user", "hello"), want: false},
+		{name: "empty message", term: "test", msg: msg("user", ""), want: false},
+		{name: "empty term matches all", term: "", msg: msg("user", "anything"), want: true},
+		{name: "does not match username", term: "julez", msg: msg("julez", "hello"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := NewContentMatcher(tt.term)
+			require.Equal(t, tt.want, m.Match(tt.msg))
+		})
+	}
+}
+
+func TestUserMatcher(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		term string
+		msg  *twitchirc.PrivateMessage
+		want bool
+	}{
+		{name: "exact match", term: "nightbot", msg: msg("Nightbot", ""), want: true},
+		{name: "substring", term: "night", msg: msg("Nightbot", ""), want: true},
+		{name: "case insensitive", term: "NIGHTBOT", msg: msg("Nightbot", ""), want: true},
+		{name: "no match", term: "streamelements", msg: msg("Nightbot", ""), want: false},
+		{name: "does not match content", term: "hello", msg: msg("user", "hello"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := NewUserMatcher(tt.term)
+			require.Equal(t, tt.want, m.Match(tt.msg))
+		})
+	}
+}
+
+func TestDefaultMatcher(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		term string
+		msg  *twitchirc.PrivateMessage
+		want bool
+	}{
+		{name: "matches content", term: "hello", msg: msg("user", "hello world"), want: true},
+		{name: "matches username", term: "julez", msg: msg("julez", "something"), want: true},
+		{name: "matches either", term: "test", msg: msg("tester", "testing"), want: true},
+		{name: "no match", term: "xyz", msg: msg("user", "hello"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := NewDefaultMatcher(tt.term)
+			require.Equal(t, tt.want, m.Match(tt.msg))
+		})
+	}
+}
+
+func TestRegexMatcher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("matches content", func(t *testing.T) {
+		t.Parallel()
+		m, err := NewRegexMatcher("hel+o")
+		require.NoError(t, err)
+		require.True(t, m.Match(msg("user", "helllllo world")))
+	})
+
+	t.Run("matches username", func(t *testing.T) {
+		t.Parallel()
+		m, err := NewRegexMatcher("^Night")
+		require.NoError(t, err)
+		require.True(t, m.Match(msg("Nightbot", "")))
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		t.Parallel()
+		m, err := NewRegexMatcher("hello")
+		require.NoError(t, err)
+		require.True(t, m.Match(msg("user", "HELLO WORLD")))
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		t.Parallel()
+		m, err := NewRegexMatcher("^exact$")
+		require.NoError(t, err)
+		require.False(t, m.Match(msg("user", "not exact match")))
+	})
+
+	t.Run("invalid pattern", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewRegexMatcher("[invalid")
+		require.Error(t, err)
+	})
+
+	t.Run("field content only", func(t *testing.T) {
+		t.Parallel()
+		m, err := NewRegexMatcherField("^hello", FieldContent)
+		require.NoError(t, err)
+		require.True(t, m.Match(msg("user", "hello world")))
+		require.False(t, m.Match(msg("hello_user", "goodbye")))
+	})
+
+	t.Run("field user only", func(t *testing.T) {
+		t.Parallel()
+		m, err := NewRegexMatcherField("^Night", FieldUser)
+		require.NoError(t, err)
+		require.True(t, m.Match(msg("Nightbot", "random")))
+		require.False(t, m.Match(msg("user", "Nightbot said hi")))
+	})
+
+	t.Run("field any matches both", func(t *testing.T) {
+		t.Parallel()
+		m, err := NewRegexMatcherField("test", FieldAny)
+		require.NoError(t, err)
+		require.True(t, m.Match(msg("tester", "nope")))
+		require.True(t, m.Match(msg("nope", "testing")))
+		require.False(t, m.Match(msg("nope", "nope")))
+	})
+}
+
+func TestBadgeMatcher(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		badge  string
+		badges []twitchirc.Badge
+		want   bool
+	}{
+		{
+			name:   "has badge",
+			badge:  "moderator",
+			badges: []twitchirc.Badge{{Name: "moderator", Version: "1"}, {Name: "subscriber", Version: "12"}},
+			want:   true,
+		},
+		{
+			name:   "case insensitive",
+			badge:  "MOD",
+			badges: []twitchirc.Badge{{Name: "moderator", Version: "1"}},
+			want:   true,
+		},
+		{
+			name:   "substring match",
+			badge:  "sub",
+			badges: []twitchirc.Badge{{Name: "subscriber", Version: "1"}},
+			want:   true,
+		},
+		{
+			name:   "no match",
+			badge:  "vip",
+			badges: []twitchirc.Badge{{Name: "moderator", Version: "1"}},
+			want:   false,
+		},
+		{
+			name:   "empty badges",
+			badge:  "mod",
+			badges: nil,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := NewBadgeMatcher(tt.badge)
+			require.Equal(t, tt.want, m.Match(&twitchirc.PrivateMessage{Badges: tt.badges}))
+		})
+	}
+}
+
+func TestPropertyMatcher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mod true", func(t *testing.T) {
+		t.Parallel()
+		m := NewPropertyMatcher(PropertyMod)
+		require.True(t, m.Match(&twitchirc.PrivateMessage{Mod: true}))
+	})
+
+	t.Run("mod false", func(t *testing.T) {
+		t.Parallel()
+		m := NewPropertyMatcher(PropertyMod)
+		require.False(t, m.Match(&twitchirc.PrivateMessage{Mod: false}))
+	})
+
+	t.Run("sub", func(t *testing.T) {
+		t.Parallel()
+		m := NewPropertyMatcher(PropertySub)
+		require.True(t, m.Match(&twitchirc.PrivateMessage{Subscriber: true}))
+		require.False(t, m.Match(&twitchirc.PrivateMessage{Subscriber: false}))
+	})
+
+	t.Run("vip", func(t *testing.T) {
+		t.Parallel()
+		m := NewPropertyMatcher(PropertyVIP)
+		require.True(t, m.Match(&twitchirc.PrivateMessage{VIP: true}))
+	})
+
+	t.Run("first", func(t *testing.T) {
+		t.Parallel()
+		m := NewPropertyMatcher(PropertyFirst)
+		require.True(t, m.Match(&twitchirc.PrivateMessage{FirstMsg: true}))
+	})
+
+	t.Run("unknown property", func(t *testing.T) {
+		t.Parallel()
+		m := NewPropertyMatcher(Property(99))
+		require.False(t, m.Match(&twitchirc.PrivateMessage{}))
+	})
+}
+
+func TestAndMatcher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all match", func(t *testing.T) {
+		t.Parallel()
+		m := NewAndMatcher(
+			NewContentMatcher("hello"),
+			NewUserMatcher("julez"),
+		)
+		require.True(t, m.Match(msg("julez", "hello world")))
+	})
+
+	t.Run("short circuits on first failure", func(t *testing.T) {
+		t.Parallel()
+		m := NewAndMatcher(
+			NewContentMatcher("xyz"),
+			NewUserMatcher("julez"),
+		)
+		require.False(t, m.Match(msg("julez", "hello")))
+	})
+
+	t.Run("empty matchers matches all", func(t *testing.T) {
+		t.Parallel()
+		m := NewAndMatcher()
+		require.True(t, m.Match(msg("user", "hello")))
+	})
+}
+
+func TestNotMatcher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inverts true to false", func(t *testing.T) {
+		t.Parallel()
+		m := NewNotMatcher(NewContentMatcher("hello"))
+		require.False(t, m.Match(msg("user", "hello")))
+	})
+
+	t.Run("inverts false to true", func(t *testing.T) {
+		t.Parallel()
+		m := NewNotMatcher(NewContentMatcher("hello"))
+		require.True(t, m.Match(msg("user", "goodbye")))
+	})
+}

--- a/search/parse.go
+++ b/search/parse.go
@@ -1,0 +1,284 @@
+package search
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Parse converts a query string into a Matcher tree.
+//
+// Syntax:
+//
+//	content:term        message content substring
+//	msg:term            alias for content:
+//	user:term           username substring
+//	from:term           alias for user:
+//	badge:name          badge name substring
+//	is:mod|sub|vip|first boolean property
+//	regex:pattern       regex on content + username
+//	/pattern/           shorthand for regex:
+//	-prefix:value       negation
+//	bare term           default (content OR username)
+//	"quoted value"      treated as single bare term
+//
+// Multiple tokens are combined with implicit AND.
+// Returns nil when the query is empty.
+func Parse(query string) (Matcher, error) {
+	tokens, err := tokenize(query)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+
+	matchers := make([]Matcher, 0, len(tokens))
+
+	for _, tok := range tokens {
+		m, err := tokenToMatcher(tok)
+		if err != nil {
+			return nil, err
+		}
+
+		matchers = append(matchers, m)
+	}
+
+	if len(matchers) == 1 {
+		return matchers[0], nil
+	}
+
+	return NewAndMatcher(matchers...), nil
+}
+
+// token represents a parsed query token before it becomes a Matcher.
+type token struct {
+	prefix  string // "" for bare terms, "content", "user", etc.
+	value   string
+	negated bool
+	isRegex bool // /pattern/ syntax
+}
+
+// tokenize splits a query string into structured tokens.
+func tokenize(query string) ([]token, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, nil
+	}
+
+	var tokens []token
+	i := 0
+
+	for i < len(query) {
+		// skip whitespace
+		if query[i] == ' ' || query[i] == '\t' {
+			i++
+			continue
+		}
+
+		tok, advance, err := readToken(query[i:])
+		if err != nil {
+			return nil, err
+		}
+
+		if tok.value != "" || tok.prefix != "" {
+			tokens = append(tokens, tok)
+		}
+
+		i += advance
+	}
+
+	return tokens, nil
+}
+
+// readToken reads a single token from the start of s and returns how many bytes were consumed.
+func readToken(s string) (token, int, error) {
+	var tok token
+	i := 0
+
+	// check negation prefix
+	if len(s) > 1 && s[0] == '-' {
+		tok.negated = true
+		i++
+	}
+
+	remaining := s[i:]
+
+	// check /regex/ syntax
+	if len(remaining) > 0 && remaining[0] == '/' {
+		return readRegexToken(s, i, tok.negated)
+	}
+
+	// check quoted string
+	if len(remaining) > 0 && remaining[0] == '"' {
+		return readQuotedToken(s, i, tok.negated)
+	}
+
+	// read a word (until whitespace)
+	word, consumed := readWord(remaining)
+	i += consumed
+
+	// check for prefix:value
+	if colonIdx := strings.IndexByte(word, ':'); colonIdx > 0 {
+		tok.prefix = strings.ToLower(word[:colonIdx])
+		tok.value = word[colonIdx+1:]
+
+		return tok, i, nil
+	}
+
+	// bare word
+	tok.value = word
+
+	return tok, i, nil
+}
+
+// readRegexToken parses /pattern/ syntax.
+func readRegexToken(s string, start int, negated bool) (token, int, error) {
+	// start is at the position after optional '-', pointing to '/'
+	i := start + 1 // skip opening '/'
+
+	closingSlash := strings.IndexByte(s[i:], '/')
+	if closingSlash == -1 {
+		// no closing slash — treat the whole original input (including any '-' prefix) as a bare word
+		word, consumed := readWord(s)
+
+		return token{value: word}, consumed, nil
+	}
+
+	pattern := s[i : i+closingSlash]
+	end := i + closingSlash + 1 // past closing '/'
+
+	return token{
+		value:   pattern,
+		negated: negated,
+		isRegex: true,
+	}, end, nil
+}
+
+// readQuotedToken parses "quoted value" syntax.
+func readQuotedToken(s string, start int, negated bool) (token, int, error) {
+	i := start + 1 // skip opening '"'
+
+	closingQuote := strings.IndexByte(s[i:], '"')
+	if closingQuote == -1 {
+		// no closing quote — take everything to end
+		return token{
+			value:   s[i:],
+			negated: negated,
+		}, len(s), nil
+	}
+
+	value := s[i : i+closingQuote]
+	end := i + closingQuote + 1 // past closing '"'
+
+	return token{
+		value:   value,
+		negated: negated,
+	}, end, nil
+}
+
+// readWord reads until the next whitespace and returns the word and bytes consumed.
+func readWord(s string) (string, int) {
+	for i := range len(s) {
+		if s[i] == ' ' || s[i] == '\t' {
+			return s[:i], i
+		}
+	}
+
+	return s, len(s)
+}
+
+// extractRegexValue checks if value is wrapped in /slashes/ and returns the inner pattern.
+func extractRegexValue(value string) (string, bool) {
+	if len(value) >= 2 && value[0] == '/' && value[len(value)-1] == '/' {
+		return value[1 : len(value)-1], true
+	}
+
+	return "", false
+}
+
+var errEmptyProperty = errors.New("empty property value for is: filter")
+
+// tokenToMatcher converts a parsed token into a Matcher.
+func tokenToMatcher(tok token) (Matcher, error) {
+	var m Matcher
+
+	switch {
+	case tok.isRegex:
+		rm, err := NewRegexMatcher(tok.value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regex /%s/: %w", tok.value, err)
+		}
+
+		m = rm
+	case tok.prefix == "":
+		m = NewDefaultMatcher(tok.value)
+	case tok.prefix == "content" || tok.prefix == "msg":
+		if pattern, ok := extractRegexValue(tok.value); ok {
+			rm, err := NewRegexMatcherField(pattern, FieldContent)
+			if err != nil {
+				return nil, fmt.Errorf("invalid regex in %s: %w", tok.prefix, err)
+			}
+
+			m = rm
+		} else {
+			m = NewContentMatcher(tok.value)
+		}
+	case tok.prefix == "user" || tok.prefix == "from":
+		if pattern, ok := extractRegexValue(tok.value); ok {
+			rm, err := NewRegexMatcherField(pattern, FieldUser)
+			if err != nil {
+				return nil, fmt.Errorf("invalid regex in %s: %w", tok.prefix, err)
+			}
+
+			m = rm
+		} else {
+			m = NewUserMatcher(tok.value)
+		}
+	case tok.prefix == "badge":
+		m = NewBadgeMatcher(tok.value)
+	case tok.prefix == "regex":
+		rm, err := NewRegexMatcher(tok.value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regex pattern: %w", err)
+		}
+
+		m = rm
+	case tok.prefix == "is":
+		pm, err := parsePropertyMatcher(tok.value)
+		if err != nil {
+			return nil, err
+		}
+
+		m = pm
+	default:
+		// unknown prefix — treat entire prefix:value as bare term
+		m = NewDefaultMatcher(tok.prefix + ":" + tok.value)
+	}
+
+	if tok.negated {
+		m = NewNotMatcher(m)
+	}
+
+	return m, nil
+}
+
+func parsePropertyMatcher(value string) (Matcher, error) {
+	switch strings.ToLower(value) {
+	case "mod":
+		return NewPropertyMatcher(PropertyMod), nil
+	case "sub":
+		return NewPropertyMatcher(PropertySub), nil
+	case "vip":
+		return NewPropertyMatcher(PropertyVIP), nil
+	case "first":
+		return NewPropertyMatcher(PropertyFirst), nil
+	default:
+		if value == "" {
+			return nil, errEmptyProperty
+		}
+
+		return nil, fmt.Errorf("unknown property %q (valid: mod, sub, vip, first)", value)
+	}
+}

--- a/search/parse_test.go
+++ b/search/parse_test.go
@@ -1,0 +1,293 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/julez-dev/chatuino/twitch/twitchirc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse_Structure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		query    string
+		wantType string // expected top-level matcher type
+		wantErr  bool
+		wantNil  bool
+	}{
+		{name: "empty", query: "", wantNil: true},
+		{name: "whitespace only", query: "   ", wantNil: true},
+		{name: "bare term", query: "hello", wantType: "*search.DefaultMatcher"},
+		{name: "content prefix", query: "content:hello", wantType: "*search.ContentMatcher"},
+		{name: "msg prefix alias", query: "msg:hello", wantType: "*search.ContentMatcher"},
+		{name: "user prefix", query: "user:julez", wantType: "*search.UserMatcher"},
+		{name: "from prefix alias", query: "from:julez", wantType: "*search.UserMatcher"},
+		{name: "badge prefix", query: "badge:mod", wantType: "*search.BadgeMatcher"},
+		{name: "is:mod", query: "is:mod", wantType: "*search.PropertyMatcher"},
+		{name: "is:sub", query: "is:sub", wantType: "*search.PropertyMatcher"},
+		{name: "is:vip", query: "is:vip", wantType: "*search.PropertyMatcher"},
+		{name: "is:first", query: "is:first", wantType: "*search.PropertyMatcher"},
+		{name: "regex prefix", query: "regex:hel+o", wantType: "*search.RegexMatcher"},
+		{name: "regex slash syntax", query: "/hel+o/", wantType: "*search.RegexMatcher"},
+		{name: "negated", query: "-user:bot", wantType: "*search.NotMatcher"},
+		{name: "two tokens AND", query: "user:julez content:gg", wantType: "*search.AndMatcher"},
+		{name: "quoted value", query: `"hello world"`, wantType: "*search.DefaultMatcher"},
+		{name: "unknown prefix as bare", query: "foo:bar", wantType: "*search.DefaultMatcher"},
+		{name: "user with regex value", query: "user:/^julez$/", wantType: "*search.RegexMatcher"},
+		{name: "content with regex value", query: "content:/^hello$/", wantType: "*search.RegexMatcher"},
+		{name: "invalid regex", query: "/[invalid/", wantErr: true},
+		{name: "invalid regex prefix", query: "regex:[bad", wantErr: true},
+		{name: "invalid field regex", query: "user:/[bad/", wantErr: true},
+		{name: "invalid is value", query: "is:unknown", wantErr: true},
+		{name: "empty is value", query: "is:", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m, err := Parse(tt.query)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.wantNil {
+				require.Nil(t, m)
+				return
+			}
+
+			require.NotNil(t, m)
+
+			typeName := typeNameOf(m)
+			require.Equal(t, tt.wantType, typeName)
+		})
+	}
+}
+
+func TestParse_Behavior(t *testing.T) {
+	t.Parallel()
+
+	julez := &twitchirc.PrivateMessage{
+		DisplayName: "julez",
+		Message:     "hello world GG",
+		Mod:         true,
+		Subscriber:  true,
+		Badges:      []twitchirc.Badge{{Name: "moderator", Version: "1"}},
+	}
+
+	nightbot := &twitchirc.PrivateMessage{
+		DisplayName: "Nightbot",
+		Message:     "!song currently playing: test",
+		Subscriber:  false,
+		FirstMsg:    false,
+	}
+
+	newChatter := &twitchirc.PrivateMessage{
+		DisplayName: "newuser123",
+		Message:     "hi chat!",
+		FirstMsg:    true,
+		VIP:         false,
+	}
+
+	tests := []struct {
+		name  string
+		query string
+		msg   *twitchirc.PrivateMessage
+		want  bool
+	}{
+		// bare terms — backward compatible
+		{name: "bare matches content", query: "hello", msg: julez, want: true},
+		{name: "bare matches username", query: "julez", msg: julez, want: true},
+		{name: "bare no match", query: "xyz", msg: julez, want: false},
+
+		// content: prefix
+		{name: "content match", query: "content:GG", msg: julez, want: true},
+		{name: "content no match user", query: "content:julez", msg: julez, want: false},
+		{name: "msg alias", query: "msg:hello", msg: julez, want: true},
+
+		// user: prefix
+		{name: "user match", query: "user:julez", msg: julez, want: true},
+		{name: "user no match content", query: "user:hello", msg: julez, want: false},
+		{name: "from alias", query: "from:Night", msg: nightbot, want: true},
+
+		// regex
+		{name: "regex content", query: "/hel+o/", msg: julez, want: true},
+		{name: "regex username", query: "/^Night/", msg: nightbot, want: true},
+		{name: "regex no match", query: "/^exact$/", msg: julez, want: false},
+		{name: "regex prefix", query: "regex:world$", msg: julez, want: false},
+		{name: "regex prefix match", query: "regex:GG$", msg: julez, want: true},
+
+		// is: properties
+		{name: "is:mod match", query: "is:mod", msg: julez, want: true},
+		{name: "is:mod no match", query: "is:mod", msg: nightbot, want: false},
+		{name: "is:sub match", query: "is:sub", msg: julez, want: true},
+		{name: "is:first match", query: "is:first", msg: newChatter, want: true},
+		{name: "is:first no match", query: "is:first", msg: julez, want: false},
+
+		// badge:
+		{name: "badge match", query: "badge:moderator", msg: julez, want: true},
+		{name: "badge no match", query: "badge:subscriber", msg: nightbot, want: false},
+
+		// field-scoped regex
+		{name: "user regex match", query: "user:/^julez$/", msg: julez, want: true},
+		{name: "user regex no match content", query: "user:/hello/", msg: julez, want: false},
+		{name: "content regex match", query: "content:/^hello/", msg: julez, want: true},
+		{name: "content regex no match user", query: "content:/^julez$/", msg: julez, want: false},
+		{name: "msg regex alias", query: "msg:/world/", msg: julez, want: true},
+		{name: "from regex alias", query: "from:/^Night/", msg: nightbot, want: true},
+		{name: "field regex combined", query: "user:/^julez$/ content:/GG/", msg: julez, want: true},
+
+		// negation
+		{name: "negated user match", query: "-user:nightbot", msg: julez, want: true},
+		{name: "negated user no match", query: "-user:julez", msg: julez, want: false},
+		{name: "negated is:mod", query: "-is:mod", msg: nightbot, want: true},
+
+		// combined (AND)
+		{name: "combined match", query: "user:julez content:GG", msg: julez, want: true},
+		{name: "combined partial fail", query: "user:julez content:xyz", msg: julez, want: false},
+		{name: "combined with negation", query: "content:hello -user:nightbot", msg: julez, want: true},
+		{name: "three filters", query: "is:mod user:julez content:hello", msg: julez, want: true},
+
+		// quoted values
+		{name: "quoted bare", query: `"hello world"`, msg: julez, want: true},
+		{name: "quoted no match", query: `"world hello"`, msg: julez, want: false},
+
+		// negated regex
+		{name: "negated regex excludes", query: "-/^Night/", msg: nightbot, want: false},
+		{name: "negated regex passes", query: "-/^Night/", msg: julez, want: true},
+
+		// empty prefix value matches all
+		{name: "empty content prefix", query: "content:", msg: julez, want: true},
+		{name: "empty user prefix", query: "user:", msg: julez, want: true},
+
+		// multi-colon value
+		{name: "multi colon value", query: "content:hello:world", msg: &twitchirc.PrivateMessage{Message: "hello:world"}, want: true},
+
+		// unknown prefix treated as bare
+		{name: "unknown prefix", query: "foo:bar", msg: &twitchirc.PrivateMessage{Message: "foo:bar"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m, err := Parse(tt.query)
+			require.NoError(t, err)
+			require.NotNil(t, m)
+			require.Equal(t, tt.want, m.Match(tt.msg))
+		})
+	}
+}
+
+func TestTokenize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  string
+		tokens []token
+	}{
+		{
+			name:   "single bare word",
+			input:  "hello",
+			tokens: []token{{value: "hello"}},
+		},
+		{
+			name:   "prefixed token",
+			input:  "content:hello",
+			tokens: []token{{prefix: "content", value: "hello"}},
+		},
+		{
+			name:  "multiple tokens",
+			input: "user:julez content:gg",
+			tokens: []token{
+				{prefix: "user", value: "julez"},
+				{prefix: "content", value: "gg"},
+			},
+		},
+		{
+			name:   "negated",
+			input:  "-user:bot",
+			tokens: []token{{prefix: "user", value: "bot", negated: true}},
+		},
+		{
+			name:   "regex slash",
+			input:  "/pattern/",
+			tokens: []token{{value: "pattern", isRegex: true}},
+		},
+		{
+			name:   "negated regex",
+			input:  "-/pattern/",
+			tokens: []token{{value: "pattern", isRegex: true, negated: true}},
+		},
+		{
+			name:   "quoted string",
+			input:  `"hello world"`,
+			tokens: []token{{value: "hello world"}},
+		},
+		{
+			name:   "unclosed quote takes rest",
+			input:  `"hello world`,
+			tokens: []token{{value: "hello world"}},
+		},
+		{
+			name:   "value with multiple colons",
+			input:  "content:hello:world",
+			tokens: []token{{prefix: "content", value: "hello:world"}},
+		},
+		{
+			name:   "unclosed regex slash treated as bare word",
+			input:  "/noclose",
+			tokens: []token{{value: "/noclose"}},
+		},
+		{
+			name:   "negated unclosed regex treated as bare word",
+			input:  "-/noclose",
+			tokens: []token{{value: "-/noclose"}},
+		},
+		{
+			name:   "leading and trailing whitespace",
+			input:  "  hello  ",
+			tokens: []token{{value: "hello"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tokenize(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.tokens, got)
+		})
+	}
+}
+
+// typeNameOf returns a string representation of a matcher's concrete type for test assertions.
+func typeNameOf(m Matcher) string {
+	switch m.(type) {
+	case *ContentMatcher:
+		return "*search.ContentMatcher"
+	case *UserMatcher:
+		return "*search.UserMatcher"
+	case *DefaultMatcher:
+		return "*search.DefaultMatcher"
+	case *RegexMatcher:
+		return "*search.RegexMatcher"
+	case *BadgeMatcher:
+		return "*search.BadgeMatcher"
+	case *PropertyMatcher:
+		return "*search.PropertyMatcher"
+	case *AndMatcher:
+		return "*search.AndMatcher"
+	case *NotMatcher:
+		return "*search.NotMatcher"
+	default:
+		return "unknown"
+	}
+}

--- a/ui/mainui/broadcast_tab.go
+++ b/ui/mainui/broadcast_tab.go
@@ -920,6 +920,14 @@ func (t *broadcastTab) State() broadcastTabState {
 	return t.state
 }
 
+func (t *broadcastTab) IsSearching() bool {
+	if t.chatWindow.state == searchChatWindowState {
+		return true
+	}
+
+	return t.userInspect != nil && t.userInspect.chatWindow.state == searchChatWindowState
+}
+
 func (t *broadcastTab) IsDataLoaded() bool {
 	return t.channelDataLoaded
 }

--- a/ui/mainui/chat.go
+++ b/ui/mainui/chat.go
@@ -15,6 +15,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/julez-dev/chatuino/save"
+	"github.com/julez-dev/chatuino/search"
 	"github.com/julez-dev/chatuino/twitch/twitchirc"
 	"github.com/julez-dev/reflow/wordwrap"
 	"github.com/julez-dev/reflow/wrap"
@@ -60,6 +61,12 @@ type position struct {
 	CursorEnd   int
 }
 
+// searchMatcher tests whether a PrivateMessage satisfies a search criterion.
+// Defined here at the point of use; implemented by the search package.
+type searchMatcher interface {
+	Match(msg *twitchirc.PrivateMessage) bool
+}
+
 type chatWindowState int
 
 const (
@@ -99,6 +106,11 @@ type chatWindow struct {
 	filteredEntries      []*chatEntry
 	filteredEntriesDirty bool
 
+	// parsed search matcher; nil when query is empty or invalid
+	currentMatcher searchMatcher
+	searchError    string
+	matchCount     int
+
 	// reusable buffer for sorting replacement keys in applyWordReplacements
 	replacementKeysBuf []string
 
@@ -129,9 +141,9 @@ type chatWindow struct {
 
 func newChatWindow(width, height int, deps *DependencyContainer) *chatWindow {
 	input := textinput.New()
-	input.CharLimit = 25
+	input.CharLimit = 128
 	input.Prompt = "  /"
-	input.Placeholder = "search"
+	input.Placeholder = "search — content: user: /regex/ badge: is:mod|sub|vip|first"
 	styles := input.Styles()
 	styles.Focused.Prompt = lipgloss.NewStyle().Foreground(lipgloss.Color(deps.UserConfig.Theme.InputPromptColor))
 	styles.Cursor.BlinkSpeed = time.Millisecond * 750
@@ -209,8 +221,8 @@ func (c *chatWindow) Update(msg tea.Msg) (*chatWindow, tea.Cmd) {
 	case tea.KeyPressMsg:
 		if c.focused {
 			switch {
-			// start search
-			case key.Matches(msg, c.deps.Keymap.SearchMode):
+			// start search (only when not already searching — otherwise '/' is forwarded to the input)
+			case key.Matches(msg, c.deps.Keymap.SearchMode) && c.state != searchChatWindowState:
 				return c, c.handleStartSearchMode()
 			// stop search
 			case key.Matches(msg, c.deps.Keymap.Escape) && c.state == searchChatWindowState:
@@ -279,6 +291,10 @@ func (c *chatWindow) handleStopSearchModeKeepSelected() {
 
 func (c *chatWindow) handleStopSearchMode() {
 	c.state = viewChatWindowState
+	c.currentMatcher = nil
+	c.searchError = ""
+	c.matchCount = 0
+
 	var last *chatEntry
 	for e := range slices.Values(c.entries) {
 		e.IsFiltered = false
@@ -343,7 +359,15 @@ func (c *chatWindow) View() string {
 	}
 
 	if c.state == searchChatWindowState {
-		return c.searchInput.View() + "\n" + strings.Join(lines, "\n")
+		searchLine := c.searchInput.View()
+
+		if c.searchError != "" {
+			searchLine += "  [!] " + c.searchError
+		} else if c.matchCount > 0 {
+			searchLine += fmt.Sprintf("  [%d matches]", c.matchCount)
+		}
+
+		return searchLine + "\n" + strings.Join(lines, "\n")
 	}
 
 	return strings.Join(lines, "\n")
@@ -681,6 +705,7 @@ func (c *chatWindow) handleMessage(msg chatEventMessage) tea.Cmd {
 	// we are currently searching and the new entry does not match the search, then ignore new entry
 	if c.state == searchChatWindowState && !c.entryMatchesSearch(entry) {
 		entry.IsFiltered = true
+		entry.Position = position{} // lines not appended; position invalid until recalculateLines
 		c.entries = append(c.entries, entry)
 	} else {
 		c.entries = append(c.entries, entry)
@@ -1128,17 +1153,14 @@ func (c *chatWindow) invalidateFilteredEntries() {
 	c.filteredEntries = nil
 }
 
-func (c *chatWindow) applySearch() {
+// clearSearchFilter un-hides all entries and resets the viewport.
+// Used when the query is too short or invalid — the user should see all messages.
+func (c *chatWindow) clearSearchFilter() {
 	var last *chatEntry
 	for e := range slices.Values(c.entries) {
+		e.IsFiltered = false
 		e.Selected = false
-		if len(c.searchInput.Value()) > 2 && c.entryMatchesSearch(e) {
-			e.IsFiltered = false
-			last = e
-			continue
-		}
-
-		e.IsFiltered = true
+		last = e
 	}
 
 	if last != nil {
@@ -1150,24 +1172,74 @@ func (c *chatWindow) applySearch() {
 	c.moveToBottom()
 }
 
-func (c *chatWindow) entryMatchesSearch(e *chatEntry) bool {
-	cast, ok := e.Event.message.(*twitchirc.PrivateMessage)
+func (c *chatWindow) applySearch() {
+	query := c.searchInput.Value()
 
+	// parse query into matcher; show all entries on empty/short/invalid input
+	if len(query) <= 2 {
+		c.currentMatcher = nil
+		c.searchError = ""
+		c.matchCount = 0
+
+		c.clearSearchFilter()
+
+		return
+	}
+
+	matcher, err := search.Parse(query)
+	if err != nil {
+		c.currentMatcher = nil
+		c.searchError = err.Error()
+		c.matchCount = 0
+
+		c.clearSearchFilter()
+
+		return
+	}
+
+	c.currentMatcher = matcher
+	c.searchError = ""
+
+	var (
+		last  *chatEntry
+		count int
+	)
+
+	for e := range slices.Values(c.entries) {
+		e.Selected = false
+		if c.entryMatchesSearch(e) {
+			e.IsFiltered = false
+			last = e
+			count++
+
+			continue
+		}
+
+		e.IsFiltered = true
+	}
+
+	c.matchCount = count
+
+	if last != nil {
+		last.Selected = true
+	}
+
+	c.invalidateFilteredEntries()
+	c.recalculateLines()
+	c.moveToBottom()
+}
+
+func (c *chatWindow) entryMatchesSearch(e *chatEntry) bool {
+	if c.currentMatcher == nil {
+		return false
+	}
+
+	cast, ok := e.Event.message.(*twitchirc.PrivateMessage)
 	if !ok {
 		return false
 	}
 
-	// search := c.searchInput.Value()
-	// if fuzzy.RankMatchFold(search, cast.DisplayName) > 5 || fuzzy.RankMatchFold(search, cast.Message) > 6 {
-	// 	return true
-	// }
-
-	search := strings.ToLower(c.searchInput.Value())
-	if strings.Contains(strings.ToLower(cast.DisplayName), search) || strings.Contains(strings.ToLower(cast.Message), search) {
-		return true
-	}
-
-	return false
+	return c.currentMatcher.Match(cast)
 }
 
 func formatBadgeReplacement(settings save.Settings, replacements map[string]string) string {

--- a/ui/mainui/help.go
+++ b/ui/mainui/help.go
@@ -126,5 +126,33 @@ func (h *help) render() string {
 		_, _ = b.WriteRune('\n')
 	}
 
+	// Search syntax reference
+	_, _ = b.WriteString(centered(lipgloss.NewStyle().Bold(true).Render("Search Syntax")))
+	_, _ = b.WriteRune('\n')
+	_, _ = b.WriteRune('\n')
+
+	searchEntries := []struct{ filter, desc string }{
+		{"hello", "message or username contains \"hello\""},
+		{"content:term", "message content contains term"},
+		{"user:term", "username contains term"},
+		{"badge:name", "user has badge (e.g. badge:moderator)"},
+		{"is:mod|sub|vip|first", "filter by user property"},
+		{"/pattern/", "regex on content and username"},
+		{"regex:pattern", "regex on content and username"},
+		{"user:/pattern/", "regex scoped to username"},
+		{"content:/pattern/", "regex scoped to content"},
+		{"-filter", "negate any filter (e.g. -user:bot)"},
+		{"\"quoted value\"", "match phrase with spaces"},
+		{"filter1 filter2", "combine filters (AND)"},
+	}
+
+	for _, entry := range searchEntries {
+		line := left(entry.filter+"  ") + right("  "+entry.desc)
+		_, _ = b.WriteString(line)
+		_, _ = b.WriteRune('\n')
+	}
+
+	_, _ = b.WriteRune('\n')
+
 	return b.String()
 }

--- a/ui/mainui/live_notification_tab.go
+++ b/ui/mainui/live_notification_tab.go
@@ -132,6 +132,10 @@ func (l *liveNotificationTab) State() broadcastTabState {
 	return l.state
 }
 
+func (l *liveNotificationTab) IsSearching() bool {
+	return l.chatWindow.state == searchChatWindowState
+}
+
 func (l *liveNotificationTab) IsDataLoaded() bool {
 	return true
 }

--- a/ui/mainui/mention_tab.go
+++ b/ui/mainui/mention_tab.go
@@ -177,6 +177,10 @@ func (m *mentionTab) State() broadcastTabState {
 	return m.state
 }
 
+func (m *mentionTab) IsSearching() bool {
+	return m.chatWindow.state == searchChatWindowState
+}
+
 func (m *mentionTab) IsDataLoaded() bool {
 	return m.hasDataLoaded
 }

--- a/ui/mainui/root.go
+++ b/ui/mainui/root.go
@@ -60,6 +60,7 @@ type tab interface {
 	AccountID() string
 	Channel() string
 	State() broadcastTabState
+	IsSearching() bool
 	IsDataLoaded() bool
 	ID() string
 	Focused() bool
@@ -635,7 +636,7 @@ func (r *Root) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			if key.Matches(msg, r.dependencies.Keymap.CloseTab) {
-				if len(r.tabs) > r.tabCursor && !(r.tabs[r.tabCursor].State() == insertMode || r.tabs[r.tabCursor].State() == userInspectInsertMode) {
+				if len(r.tabs) > r.tabCursor && !(r.tabs[r.tabCursor].State() == insertMode || r.tabs[r.tabCursor].State() == userInspectInsertMode || r.tabs[r.tabCursor].IsSearching()) {
 					currentTab := r.tabs[r.tabCursor]
 					r.closeTab()
 

--- a/web/src/components/Features.tsx
+++ b/web/src/components/Features.tsx
@@ -44,9 +44,9 @@ const features: Feature[] = [
     icon: "live",
   },
   {
-    title: "Message Search",
+    title: "Advanced Search",
     description:
-      "Search through chat history. Find messages and usernames quickly.",
+      "Filter chat with structured queries. Target content, users, badges, or use regex. Combine and negate filters freely.",
     icon: "search",
   },
   {

--- a/web/src/pages/docs/Features.tsx
+++ b/web/src/pages/docs/Features.tsx
@@ -69,7 +69,7 @@ export default function Features() {
           <li>
             Press{" "}
             <code class="rounded bg-nord1 px-1.5 py-0.5 text-nord8">/</code> to
-            start a search for messages or usernames
+            start a search (see syntax below)
           </li>
           <li>
             Press{" "}
@@ -87,6 +87,110 @@ export default function Features() {
             view all key bindings
           </li>
         </ul>
+
+        <h3 class="mb-2 mt-6 text-lg font-medium text-nord4">Search Syntax</h3>
+        <p class="mb-4 text-nord4">
+          Press <code class="rounded bg-nord1 px-1.5 py-0.5 text-nord8">/</code>{" "}
+          to open the search bar. By default, typing a term searches both
+          message content and usernames. Use prefixes to target specific fields
+          or apply advanced filters. Multiple filters are combined with AND.
+        </p>
+        <div class="mb-4 overflow-x-auto rounded-lg border border-nord2">
+          <table class="w-full text-left text-sm">
+            <thead class="border-b border-nord2 bg-nord1">
+              <tr>
+                <th class="px-4 py-2 font-semibold text-nord8">Filter</th>
+                <th class="px-4 py-2 font-semibold text-nord8">Description</th>
+              </tr>
+            </thead>
+            <tbody class="text-nord4">
+              <tr class="border-b border-nord2">
+                <td class="px-4 py-2">
+                  <code class="text-nord8">hello</code>
+                </td>
+                <td class="px-4 py-2">Message or username contains "hello"</td>
+              </tr>
+              <tr class="border-b border-nord2">
+                <td class="px-4 py-2">
+                  <code class="text-nord8">content:term</code>
+                </td>
+                <td class="px-4 py-2">Message content contains term</td>
+              </tr>
+              <tr class="border-b border-nord2">
+                <td class="px-4 py-2">
+                  <code class="text-nord8">user:term</code>
+                </td>
+                <td class="px-4 py-2">Username contains term</td>
+              </tr>
+              <tr class="border-b border-nord2">
+                <td class="px-4 py-2">
+                  <code class="text-nord8">badge:name</code>
+                </td>
+                <td class="px-4 py-2">
+                  User has badge (e.g.{" "}
+                  <code class="text-nord8">badge:moderator</code>)
+                </td>
+              </tr>
+              <tr class="border-b border-nord2">
+                <td class="px-4 py-2">
+                  <code class="text-nord8">is:mod|sub|vip|first</code>
+                </td>
+                <td class="px-4 py-2">Filter by user property</td>
+              </tr>
+              <tr class="border-b border-nord2">
+                <td class="px-4 py-2">
+                  <code class="text-nord8">/pattern/</code>
+                </td>
+                <td class="px-4 py-2">Regex on content and username</td>
+              </tr>
+              <tr class="border-b border-nord2">
+                <td class="px-4 py-2">
+                  <code class="text-nord8">user:/pattern/</code>
+                </td>
+                <td class="px-4 py-2">Regex scoped to username only</td>
+              </tr>
+              <tr class="border-b border-nord2">
+                <td class="px-4 py-2">
+                  <code class="text-nord8">content:/pattern/</code>
+                </td>
+                <td class="px-4 py-2">Regex scoped to content only</td>
+              </tr>
+              <tr class="border-b border-nord2">
+                <td class="px-4 py-2">
+                  <code class="text-nord8">-filter</code>
+                </td>
+                <td class="px-4 py-2">
+                  Negate any filter (e.g.{" "}
+                  <code class="text-nord8">-user:nightbot</code>)
+                </td>
+              </tr>
+              <tr>
+                <td class="px-4 py-2">
+                  <code class="text-nord8">"quoted value"</code>
+                </td>
+                <td class="px-4 py-2">Match a phrase with spaces</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="mb-4 text-sm text-nord4">
+          <strong class="text-nord8">Aliases:</strong>{" "}
+          <code class="rounded bg-nord1 px-1 py-0.5 text-nord8">msg:</code> for{" "}
+          <code class="rounded bg-nord1 px-1 py-0.5 text-nord8">content:</code>,{" "}
+          <code class="rounded bg-nord1 px-1 py-0.5 text-nord8">from:</code> for{" "}
+          <code class="rounded bg-nord1 px-1 py-0.5 text-nord8">user:</code>,{" "}
+          <code class="rounded bg-nord1 px-1 py-0.5 text-nord8">regex:</code>{" "}
+          for{" "}
+          <code class="rounded bg-nord1 px-1 py-0.5 text-nord8">/pattern/</code>
+        </p>
+        <p class="text-sm text-nord4">
+          <strong class="text-nord8">Example:</strong>{" "}
+          <code class="rounded bg-nord1 px-1.5 py-0.5 text-nord8">
+            user:julez content:GG is:sub
+          </code>{" "}
+          matches messages from "julez" containing "GG" that are from a
+          subscriber.
+        </p>
 
         <h3 class="mb-2 mt-6 text-lg font-medium text-nord4">
           Writing Messages


### PR DESCRIPTION
## Summary

Closes #85

Replaces the simple substring search with a composable, structured query system. Filters can target specific fields, use regex, and be combined/negated.

## Search Syntax

| Filter | Description |
|---|---|
| `hello` | message or username contains "hello" |
| `content:term` | message content contains term |
| `user:term` | username contains term |
| `badge:name` | user has badge (e.g. `badge:moderator`) |
| `is:mod\|sub\|vip\|first` | filter by user property |
| `/pattern/` | regex on content and username |
| `regex:pattern` | regex on content and username |
| `user:/pattern/` | regex scoped to username only |
| `content:/pattern/` | regex scoped to content only |
| `-filter` | negate any filter (e.g. `-user:nightbot`) |
| `"quoted value"` | match a phrase with spaces |

Multiple filters are combined with AND: `user:julez content:GG is:sub`

Aliases: `msg:` for `content:`, `from:` for `user:`

## Changes

### New `search/` package
- `Matcher` interface with 8 concrete types: `ContentMatcher`, `UserMatcher`, `DefaultMatcher`, `RegexMatcher`, `BadgeMatcher`, `PropertyMatcher`, `AndMatcher`, `NotMatcher`
- Query parser: tokenizer handles prefixed terms, `/regex/` syntax, quoted values, negation
- Field-scoped regex: `user:/^julez$/` and `content:/pattern/` create regex matchers restricted to that field
- 70+ table-driven parallel tests

### `ui/mainui/chat.go`
- `entryMatchesSearch` delegates to parsed `Matcher` instead of inline `strings.Contains`
- `applySearch` parses query once per keystroke, caches matcher for reuse by new incoming messages
- Match count displayed inline: `[N matches]`
- Parse errors shown inline: `[!] invalid regex ...`
- Char limit increased 25 → 128
- Placeholder shows available syntax
- Consumer-side `searchMatcher` interface (Go convention: define where used)

### Bug fixes
- `/` key now forwarded to text input when already in search mode (enables `/regex/` syntax)
- `ctrl+w` no longer closes tab during search mode (forwarded to text input for word deletion)
- Fixed for both main chat and user inspect search modes

### Documentation
- `doc/FEATURES.md`: full syntax reference table
- In-app help screen (`?`): search syntax section
- Landing page: feature card updated to "Advanced Search"
- Docs page: search syntax table with examples and aliases

### Performance
- Regex compiled once per query change, not per entry
- Search terms pre-lowered at parse time
- `AndMatcher` short-circuits on first non-match
- Existing filtered entry cache reused